### PR TITLE
Split image read from interpreter

### DIFF
--- a/smalltalksrc/VMMaker/CogSistaMethodSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogSistaMethodSurrogate32.class.st
@@ -19,12 +19,12 @@ CogSistaMethodSurrogate32 class >> offsetOf: aByteSymbol [
 
 { #category : #accessing }
 CogSistaMethodSurrogate32 >> counters [
-	^memory unsignedLongAt: address + 21 + baseHeaderSize
+	^memory unsignedLong32At: address + 20 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogSistaMethodSurrogate32 >> counters: aValue [
 	^memory
-		unsignedLongAt: address + baseHeaderSize + 21
+		unsignedLong32At: address + baseHeaderSize + 20
 		put: aValue
 ]

--- a/smalltalksrc/VMMaker/CogSistaMethodSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogSistaMethodSurrogate64.class.st
@@ -19,12 +19,12 @@ CogSistaMethodSurrogate64 class >> offsetOf: aByteSymbol [
 
 { #category : #accessing }
 CogSistaMethodSurrogate64 >> counters [
-	^memory unsignedLong64At: address + 33 + baseHeaderSize
+	^memory unsignedLong64At: address + 32 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogSistaMethodSurrogate64 >> counters: aValue [
 	^memory
-		unsignedLong64At: address + baseHeaderSize + 33
+		unsignedLong64At: address + baseHeaderSize + 32
 		put: aValue
 ]

--- a/smalltalksrc/VMMaker/CogStackPageSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogStackPageSurrogate64.class.st
@@ -85,13 +85,13 @@ CogStackPageSurrogate64 >> lastAddress: aValue [
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> nextPage [
-	^stackPages surrogateAtAddress: (memory unsignedLong64At: address + 60)
+	^stackPages surrogateAtAddress: (memory unsignedLong64At: address + 64)
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> nextPage: aValue [
-	self assert: (address + 60 >= zoneBase and: [address + 67 < zoneLimit]).
-	memory unsignedLong64At: address + 60 put: aValue asInteger.
+	self assert: (address + 64 >= zoneBase and: [address + 71 < zoneLimit]).
+	memory unsignedLong64At: address + 64 put: aValue asInteger.
 	^aValue
 ]
 
@@ -108,13 +108,13 @@ CogStackPageSurrogate64 >> padToWord: aValue [
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> prevPage [
-	^stackPages surrogateAtAddress: (memory unsignedLong64At: address + 68)
+	^stackPages surrogateAtAddress: (memory unsignedLong64At: address + 72)
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> prevPage: aValue [
-	self assert: (address + 68 >= zoneBase and: [address + 75 < zoneLimit]).
-	memory unsignedLong64At: address + 68 put: aValue asInteger.
+	self assert: (address + 72 >= zoneBase and: [address + 79 < zoneLimit]).
+	memory unsignedLong64At: address + 72 put: aValue asInteger.
 	^aValue
 ]
 

--- a/smalltalksrc/VMMaker/CogVMSimulator.class.st
+++ b/smalltalksrc/VMMaker/CogVMSimulator.class.st
@@ -1052,15 +1052,6 @@ CogVMSimulator >> functionPointerForCompiledMethod: methodObj primitiveIndex: pr
 	^self mapFunctionToAddress: (super functionPointerForCompiledMethod: methodObj primitiveIndex: primIndex)
 ]
 
-{ #category : #'image save/restore' }
-CogVMSimulator >> getShortFromFile: aFile swap: swapFlag [
-	| aShort |
-	aShort := self nextShortFrom: aFile.
-	^swapFlag 
-		ifTrue: [(aShort bitShift: -8) + ((aShort bitAnd: 16rFF) bitShift: 8)]
-		ifFalse: [aShort]
-]
-
 { #category : #'memory access' }
 CogVMSimulator >> halfWordHighInLong32: long32 [
 	^self subclassResponsibility

--- a/smalltalksrc/VMMaker/ImageReader.class.st
+++ b/smalltalksrc/VMMaker/ImageReader.class.st
@@ -16,7 +16,7 @@ ImageReader class >> newWithMemory: memory [
 	^ imageReader
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ImageReader >> extractImageVersionFrom: file into: header [
 	"Read and verify the image file version number and return true if the the given image file needs to be byte-swapped. As a side effect, position the file stream just after the version number of the image header. This code prints a warning and does a hard-exit if it cannot find a valid version number."
 	"This code is based on C code by Ian Piumarta."
@@ -50,7 +50,7 @@ ImageReader >> extractImageVersionFrom: file into: header [
 
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ImageReader >> getLongFromFile: aFile swap: swapFlag [
 	"Answer the next 32 or 64 bit word read from aFile, byte-swapped according to the swapFlag."
 	<var: #aFile type: #sqImageFile>
@@ -68,7 +68,7 @@ ImageReader >> getLongFromFile: aFile swap: swapFlag [
 		ifFalse: [w]
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ImageReader >> getShortFromFile: aFile swap: swapFlag [
 	"Answer the next 16 bit word read from aFile, byte-swapped according to the swapFlag."
 
@@ -87,7 +87,7 @@ ImageReader >> getShortFromFile: aFile swap: swapFlag [
 		ifFalse: [w]
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ImageReader >> getWord32FromFile: aFile swap: swapFlag [
 	"Answer the next 32 bit word read from aFile, byte-swapped according to the swapFlag."
 
@@ -106,14 +106,14 @@ ImageReader >> getWord32FromFile: aFile swap: swapFlag [
 		ifFalse: [w]
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ImageReader >> imageFormatCompatibilityVersion [
 	"This VM is backward-compatible with the immediately preceding version."
 
 	^objectMemory wordSize = 4 ifTrue: [6504] ifFalse: [68002]
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ImageReader >> imageFormatVersion [
 	"Return a magic constant that changes when the image format changes.
 	 Since the image reading code uses this to detect byte ordering, one
@@ -132,7 +132,7 @@ ImageReader >> objectMemory: memory [
 	objectMemory := memory
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ImageReader >> readHeaderFrom: f startingAt: headerStart [
 
 	<var: #f type: #sqImageFile>
@@ -183,7 +183,7 @@ ImageReader >> readHeaderFrom: f startingAt: headerStart [
 	^ header
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ImageReader >> readableFormat: imageVersion [
 	"Anwer true if images of the given format are readable by this interpreter.
 	 Allows a virtual machine to accept selected older image formats."

--- a/smalltalksrc/VMMaker/ImageReader.class.st
+++ b/smalltalksrc/VMMaker/ImageReader.class.st
@@ -7,6 +7,15 @@ Class {
 	#category : #'VMMaker-Support'
 }
 
+{ #category : #'instance creation' }
+ImageReader class >> newWithMemory: memory [
+
+	| imageReader |
+	imageReader := self new.
+	imageReader objectMemory: memory.
+	^ imageReader
+]
+
 { #category : #accessing }
 ImageReader >> extractImageVersionFrom: file into: header [
 	"Read and verify the image file version number and return true if the the given image file needs to be byte-swapped. As a side effect, position the file stream just after the version number of the image header. This code prints a warning and does a hard-exit if it cannot find a valid version number."
@@ -109,6 +118,8 @@ ImageReader >> imageFormatVersion [
 	"Return a magic constant that changes when the image format changes.
 	 Since the image reading code uses this to detect byte ordering, one
 	 must avoid version numbers that are invariant under byte reversal."
+	
+	"THIS METHOD KEEP DUPLICATED IN StackInterpreter UNTIL SPLIT IMAGE WRITTER"
 	<doNotGenerate>
 	self assert: (objectMemory imageFormatVersion anyMask: 16) = objectMemory hasSpurMemoryManagerAPI.
 	^objectMemory imageFormatVersion

--- a/smalltalksrc/VMMaker/ImageReader.class.st
+++ b/smalltalksrc/VMMaker/ImageReader.class.st
@@ -1,0 +1,183 @@
+Class {
+	#name : #ImageReader,
+	#superclass : #VMClass,
+	#instVars : [
+		'objectMemory'
+	],
+	#category : #'VMMaker-Support'
+}
+
+{ #category : #accessing }
+ImageReader >> extractImageVersionFrom: file into: header [
+	"Read and verify the image file version number and return true if the the given image file needs to be byte-swapped. As a side effect, position the file stream just after the version number of the image header. This code prints a warning and does a hard-exit if it cannot find a valid version number."
+	"This code is based on C code by Ian Piumarta."
+
+	<inline: false>
+	| version firstVersion |
+	<var: #file type: #sqImageFile>
+	<var: #imageOffset type: #squeakFileOffsetType>
+	<var: #header type: #SpurImageHeaderStruct>
+
+	"check the version number"
+	version := firstVersion := self getWord32FromFile: file swap: false.
+	(self readableFormat: version) ifTrue: [
+		header imageFormat: version.
+		header swapBytes: false.
+		^ self].
+
+	"try with bytes reversed"
+	(self readableFormat: version byteSwap32) 
+		ifTrue: [
+			header imageFormat: version byteSwap32.
+			header swapBytes: true.
+			^ self].
+
+	"hard failure; abort"
+	self logError: 'Invalid image format: detected version %d, expected version %d' 
+		_: firstVersion 
+		_: self imageFormatVersion.
+	
+	self ioExitWithErrorCode: 1.
+
+]
+
+{ #category : #accessing }
+ImageReader >> getLongFromFile: aFile swap: swapFlag [
+	"Answer the next 32 or 64 bit word read from aFile, byte-swapped according to the swapFlag."
+	<var: #aFile type: #sqImageFile>
+	<var: #w type: #usqInt>
+	| w |
+	w := 0.
+	self cCode: [self
+					sq: (self addressOf: w)
+					Image: (self sizeof: w)
+					File: 1
+					Read: aFile]
+		inSmalltalk: [w := objectMemory nextLongFrom: aFile].
+	^swapFlag
+		ifTrue: [objectMemory byteSwapped: w]
+		ifFalse: [w]
+]
+
+{ #category : #accessing }
+ImageReader >> getShortFromFile: aFile swap: swapFlag [
+	"Answer the next 16 bit word read from aFile, byte-swapped according to the swapFlag."
+
+	<var: #aFile type: #sqImageFile>
+	| w |
+	<var: #w type: #'unsigned short'>
+	w := 0.
+	self cCode: [self
+					sq: (self addressOf: w)
+					Image: (self sizeof: #'unsigned short')
+					File: 1
+					Read: aFile]
+		inSmalltalk: [w := aFile nextLittleEndianNumber: 2].
+	^swapFlag
+		ifTrue: [((w >> 8) bitAnd: 16rFF) bitOr: ((w bitAnd: 16rFF) << 8)]
+		ifFalse: [w]
+]
+
+{ #category : #accessing }
+ImageReader >> getWord32FromFile: aFile swap: swapFlag [
+	"Answer the next 32 bit word read from aFile, byte-swapped according to the swapFlag."
+
+	<var: #aFile type: #sqImageFile>
+	| w |
+	<var: #w type: #int>
+	w := 0.
+	self cCode: [self
+					sq: (self addressOf: w)
+					Image: (self sizeof: #int)
+					File: 1
+					Read: aFile]
+		inSmalltalk: [w := objectMemory nextWord32From: aFile].
+	^swapFlag
+		ifTrue: [w byteSwap32]
+		ifFalse: [w]
+]
+
+{ #category : #accessing }
+ImageReader >> imageFormatCompatibilityVersion [
+	"This VM is backward-compatible with the immediately preceding version."
+
+	^objectMemory wordSize = 4 ifTrue: [6504] ifFalse: [68002]
+]
+
+{ #category : #accessing }
+ImageReader >> imageFormatVersion [
+	"Return a magic constant that changes when the image format changes.
+	 Since the image reading code uses this to detect byte ordering, one
+	 must avoid version numbers that are invariant under byte reversal."
+	<doNotGenerate>
+	self assert: (objectMemory imageFormatVersion anyMask: 16) = objectMemory hasSpurMemoryManagerAPI.
+	^objectMemory imageFormatVersion
+]
+
+{ #category : #accessing }
+ImageReader >> objectMemory: memory [
+
+	<doNotGenerate>
+	objectMemory := memory
+]
+
+{ #category : #accessing }
+ImageReader >> readHeaderFrom: f startingAt: headerStart [
+
+	<var: #f type: #sqImageFile>
+	<var: #headerStart type: #squeakFileOffsetType>
+	<var: #header type: #SpurImageHeaderStruct>
+	<returnTypeC: #SpurImageHeaderStruct>
+	| header |
+	self simulationOnly: [ header := SpurImageHeaderStruct new ].
+
+	self extractImageVersionFrom: f into: header.
+
+	header headerSize: (self getWord32FromFile: f swap: header swapBytes).
+	header dataSize: (self getLongFromFile: f swap: header swapBytes).
+	header oldBaseAddr: (self getLongFromFile: f swap: header swapBytes).
+	header initialSpecialObjectsOop:
+		(self getLongFromFile: f swap: header swapBytes).
+
+	header hdrLastHash: (self getLongFromFile: f swap: header swapBytes).
+
+	"savedWindowSize :="
+	self getLongFromFile: f swap: header swapBytes.
+	header headerFlags: (self getLongFromFile: f swap: header swapBytes).
+
+	header extraVMMemory:
+		(self getWord32FromFile: f swap: header swapBytes).
+	header hdrNumStackPages:
+		(self getShortFromFile: f swap: header swapBytes).
+	"This slot holds the size of the native method zone in 1k units. (pad to word boundary)."
+	header hdrCogCodeSize:
+		(self getShortFromFile: f swap: header swapBytes) * 1024.
+	header hdrEdenBytes:
+		(self getWord32FromFile: f swap: header swapBytes).
+
+	header hdrMaxExtSemTabSize:
+		(self getShortFromFile: f swap: header swapBytes).
+	"pad to word boundary.  This slot can be used for anything else that will fit in 16 bits.
+	 Preserve it to be polite to other VMs."
+	"the2ndUnknownShort :="
+	self getShortFromFile: f swap: header swapBytes.
+	header firstSegSize: (self getLongFromFile: f swap: header swapBytes).
+
+	header freeOldSpaceInImage:
+		(self getLongFromFile: f swap: header swapBytes).
+
+	"position file after the header"
+	self sqImageFile: f Seek: headerStart + header headerSize.
+
+	^ header
+]
+
+{ #category : #accessing }
+ImageReader >> readableFormat: imageVersion [
+	"Anwer true if images of the given format are readable by this interpreter.
+	 Allows a virtual machine to accept selected older image formats."
+
+	^imageVersion = self imageFormatVersion "Float words in platform-order"
+	   or: [objectMemory hasSpurMemoryManagerAPI not "No compatibility version for Spur as yet"
+			and: [imageVersion = self imageFormatCompatibilityVersion]] "Float words in BigEndian order"
+]

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1693,7 +1693,7 @@ StackInterpreter class >> requiredMethodNames: options [
 		primitiveFail primitiveFailFor: primitiveFlushExternalPrimitives printAllStacks printCallStack printContext:
 			printExternalHeadFrame printFramesInPage: printFrame: printHeadFrame printMemory printOop:
 				printStackPages printStackPageList printStackPagesInUse printStackPageListInUse
-		readableFormat: readImageFromFile:StartingAt:
+		readImageFromFile:StartingAt:
 		setFullScreenFlag: setInterruptKeycode: setInterruptPending: setInterruptCheckChain:
 			setSavedWindowSize: success:
 		validInstructionPointer:inMethod:framePointer:) asSet.
@@ -5969,40 +5969,6 @@ StackInterpreter >> extraVMMemory: anInteger [
 	extraVMMemory := anInteger
 ]
 
-{ #category : #'image save/restore' }
-StackInterpreter >> extractImageVersionFrom: file into: header [
-	"Read and verify the image file version number and return true if the the given image file needs to be byte-swapped. As a side effect, position the file stream just after the version number of the image header. This code prints a warning and does a hard-exit if it cannot find a valid version number."
-	"This code is based on C code by Ian Piumarta."
-
-	<inline: false>
-	| version firstVersion |
-	<var: #file type: #sqImageFile>
-	<var: #imageOffset type: #squeakFileOffsetType>
-	<var: #header type: #SpurImageHeaderStruct>
-
-	"check the version number"
-	version := firstVersion := self getWord32FromFile: file swap: false.
-	(self readableFormat: version) ifTrue: [
-		header imageFormat: version.
-		header swapBytes: false.
-		^ self].
-
-	"try with bytes reversed"
-	(self readableFormat: version byteSwap32) 
-		ifTrue: [
-			header imageFormat: version byteSwap32.
-			header swapBytes: true.
-			^ self].
-
-	"hard failure; abort"
-	self logError: 'Invalid image format: detected version %d, expected version %d' 
-		_: firstVersion 
-		_: self imageFormatVersion.
-	
-	self ioExitWithErrorCode: 1.
-
-]
-
 { #category : #'primitive support' }
 StackInterpreter >> failUnbalancedPrimitive [
 	"not inlined for breakpoint value..."
@@ -7245,24 +7211,6 @@ StackInterpreter >> getInterruptPending [
 	^interruptPending
 ]
 
-{ #category : #'image save/restore' }
-StackInterpreter >> getLongFromFile: aFile swap: swapFlag [
-	"Answer the next 32 or 64 bit word read from aFile, byte-swapped according to the swapFlag."
-	<var: #aFile type: #sqImageFile>
-	<var: #w type: #usqInt>
-	| w |
-	w := 0.
-	self cCode: [self
-					sq: (self addressOf: w)
-					Image: (self sizeof: w)
-					File: 1
-					Read: aFile]
-		inSmalltalk: [w := objectMemory nextLongFrom: aFile].
-	^swapFlag
-		ifTrue: [objectMemory byteSwapped: w]
-		ifFalse: [w]
-]
-
 { #category : #'internal interpreter access' }
 StackInterpreter >> getMethodCompilationCount [
 	"This is nil in the StackVM"
@@ -7285,25 +7233,6 @@ StackInterpreter >> getNextWakeupUsecs [
 { #category : #'plugin primitive support' }
 StackInterpreter >> getSavedWindowSize [
 	^savedWindowSize
-]
-
-{ #category : #'image save/restore' }
-StackInterpreter >> getShortFromFile: aFile swap: swapFlag [
-	"Answer the next 16 bit word read from aFile, byte-swapped according to the swapFlag."
-
-	<var: #aFile type: #sqImageFile>
-	| w |
-	<var: #w type: #'unsigned short'>
-	w := 0.
-	self cCode: [self
-					sq: (self addressOf: w)
-					Image: (self sizeof: #'unsigned short')
-					File: 1
-					Read: aFile]
-		inSmalltalk: [w := objectMemory nextShortFrom: aFile].
-	^swapFlag
-		ifTrue: [((w >> 8) bitAnd: 16rFF) bitOr: ((w bitAnd: 16rFF) << 8)]
-		ifFalse: [w]
 ]
 
 { #category : #'internal interpreter access' }
@@ -7331,25 +7260,6 @@ StackInterpreter >> getThisSessionID [
 	"return the global session ID value"
 	<inline: false>
 	^globalSessionID
-]
-
-{ #category : #'image save/restore' }
-StackInterpreter >> getWord32FromFile: aFile swap: swapFlag [
-	"Answer the next 32 bit word read from aFile, byte-swapped according to the swapFlag."
-
-	<var: #aFile type: #sqImageFile>
-	| w |
-	<var: #w type: #int>
-	w := 0.
-	self cCode: [self
-					sq: (self addressOf: w)
-					Image: (self sizeof: #int)
-					File: 1
-					Read: aFile]
-		inSmalltalk: [w := objectMemory nextWord32From: aFile].
-	^swapFlag
-		ifTrue: [w byteSwap32]
-		ifFalse: [w]
 ]
 
 { #category : #'message sending' }
@@ -7641,13 +7551,6 @@ StackInterpreter >> iframeMethod: theFP [
 	<var: #theFP type: #'char *'>
 	<returnTypeC: #usqInt>
 	^stackPages longAt: theFP + FoxMethod
-]
-
-{ #category : #'image save/restore' }
-StackInterpreter >> imageFormatCompatibilityVersion [
-	"This VM is backward-compatible with the immediately preceding version."
-
-	^objectMemory wordSize = 4 ifTrue: [6504] ifFalse: [68002]
 ]
 
 { #category : #'image save/restore' }
@@ -13030,57 +12933,6 @@ StackInterpreter >> quinaryInlinePrimitive: primIndex [
 ]
 
 { #category : #'image save/restore' }
-StackInterpreter >> readHeaderFrom: f startingAt: headerStart [
-
-	<var: #f type: #sqImageFile>
-	<var: #headerStart type: #squeakFileOffsetType>
-	<var: #header type: #SpurImageHeaderStruct>
-	<returnTypeC: #SpurImageHeaderStruct>
-	| header |
-	self simulationOnly: [ header := SpurImageHeaderStruct new ].
-
-	self extractImageVersionFrom: f into: header.
-
-	header headerSize: (self getWord32FromFile: f swap: header swapBytes).
-	header dataSize: (self getLongFromFile: f swap: header swapBytes).
-	header oldBaseAddr: (self getLongFromFile: f swap: header swapBytes).
-	header initialSpecialObjectsOop:
-		(self getLongFromFile: f swap: header swapBytes).
-
-	header hdrLastHash: (self getLongFromFile: f swap: header swapBytes).
-
-	"savedWindowSize :="
-	self getLongFromFile: f swap: header swapBytes.
-	header headerFlags: (self getLongFromFile: f swap: header swapBytes).
-
-	header extraVMMemory:
-		(self getWord32FromFile: f swap: header swapBytes).
-	header hdrNumStackPages:
-		(self getShortFromFile: f swap: header swapBytes).
-	"This slot holds the size of the native method zone in 1k units. (pad to word boundary)."
-	header hdrCogCodeSize:
-		(self getShortFromFile: f swap: header swapBytes) * 1024.
-	header hdrEdenBytes:
-		(self getWord32FromFile: f swap: header swapBytes).
-
-	header hdrMaxExtSemTabSize:
-		(self getShortFromFile: f swap: header swapBytes).
-	"pad to word boundary.  This slot can be used for anything else that will fit in 16 bits.
-	 Preserve it to be polite to other VMs."
-	"the2ndUnknownShort :="
-	self getShortFromFile: f swap: header swapBytes.
-	header firstSegSize: (self getLongFromFile: f swap: header swapBytes).
-
-	header freeOldSpaceInImage:
-		(self getLongFromFile: f swap: header swapBytes).
-
-	"position file after the header"
-	self sqImageFile: f Seek: headerStart + header headerSize.
-
-	^ header
-]
-
-{ #category : #'image save/restore' }
 StackInterpreter >> readImageFromFile: f StartingAt: headerStart [
 
 	"Read an image from the given file stream, allocating an amount of memory to its object heap.
@@ -13111,7 +12963,7 @@ StackInterpreter >> readImageFromFile: f StartingAt: headerStart [
 	metaclassNumSlots := 6. "guess Metaclass instSize"
 	classNameIndex := 6. "guess (Class instVarIndexFor: 'name' ifAbsent: []) - 1"
 
-	header := self readHeaderFrom: f startingAt: headerStart.
+	header := (ImageReader newWithMemory: objectMemory) readHeaderFrom: f startingAt: headerStart.
 
 	objectMemory specialObjectsOop: header initialSpecialObjectsOop.
 	objectMemory lastHash: header hdrLastHash.
@@ -13147,16 +12999,6 @@ StackInterpreter >> readImageFromFile: f StartingAt: headerStart [
 	self allocateMemoryForImage: f withHeader: header.
 
 	^ header dataSize
-]
-
-{ #category : #'image save/restore' }
-StackInterpreter >> readableFormat: imageVersion [
-	"Anwer true if images of the given format are readable by this interpreter.
-	 Allows a virtual machine to accept selected older image formats."
-
-	^imageVersion = self imageFormatVersion "Float words in platform-order"
-	   or: [objectMemory hasSpurMemoryManagerAPI not "No compatibility version for Spur as yet"
-			and: [imageVersion = self imageFormatCompatibilityVersion]] "Float words in BigEndian order"
 ]
 
 { #category : #'primitive support' }

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -4312,13 +4312,6 @@ StackInterpreterPrimitives >> readAddress: anOop [
 	^ objectMemory fetchPointer: 0 ofObject: anOop.
 ]
 
-{ #category : #'I/O primitive support' }
-StackInterpreterPrimitives >> sqImageFile: imageFile Seek: position [
-
-	<doNotGenerate>
-	imageFile position: position
-]
-
 { #category : #'object access primitives' }
 StackInterpreterPrimitives >> unmarkAfterPathTo [
 	<inline: false>

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -718,15 +718,6 @@ StackInterpreterSimulator >> getErrorObjectFromPrimFailCode [
 	^super getErrorObjectFromPrimFailCode
 ]
 
-{ #category : #'image save/restore' }
-StackInterpreterSimulator >> getShortFromFile: aFile swap: swapFlag [
-	| aShort |
-	aShort := self nextShortFrom: aFile.
-	^swapFlag 
-		ifTrue: [(aShort bitShift: -8) + ((aShort bitAnd: 16rFF) bitShift: 8)]
-		ifFalse: [aShort]
-]
-
 { #category : #'memory access' }
 StackInterpreterSimulator >> halfWordHighInLong32: long32 [
 	^self subclassResponsibility

--- a/smalltalksrc/VMMaker/VMClass.class.st
+++ b/smalltalksrc/VMMaker/VMClass.class.st
@@ -1097,6 +1097,13 @@ VMClass >> singleFloatAtPointer: pointer put: value [
 	self halt.
 ]
 
+{ #category : #'I/O primitive support' }
+VMClass >> sqImageFile: imageFile Seek: position [
+
+	<doNotGenerate>
+	imageFile position: position
+]
+
 { #category : #'simulation support' }
 VMClass >> sqLowLevelMFence [
 	<doNotGenerate>

--- a/smalltalksrc/VMMakerTests/VMSpurImageFormatTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurImageFormatTest.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #VMSpurImageFormatTest,
 	#superclass : #VMSpurInitializedOldSpaceTest,
+	#instVars : [
+		'imageReader'
+	],
 	#category : #'VMMakerTests-MemoryTests'
 }
 
@@ -9,7 +12,7 @@ VMSpurImageFormatTest >> readHeader [
 
 	| header |
 	header := 'lala.image' asFileReference binaryReadStreamDo: [ :f | 
-		          interpreter readHeaderFrom: f startingAt: 0 ].
+		          imageReader readHeaderFrom: f startingAt: 0 ].
 	^ header
 ]
 
@@ -29,6 +32,9 @@ VMSpurImageFormatTest >> setUp [
 	interpreter setImageHeaderFlagsFrom: 0.
 	
 	interpreter writeImageFileIO.
+	
+	imageReader := ImageReader new.
+	imageReader objectMemory: memory
 ]
 
 { #category : #tests }

--- a/smalltalksrc/VMMakerTests/VMSpurImageFormatTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurImageFormatTest.class.st
@@ -8,10 +8,16 @@ Class {
 }
 
 { #category : #tests }
+VMSpurImageFormatTest >> imageFileName [
+
+	^ 'lala.image'
+]
+
+{ #category : #tests }
 VMSpurImageFormatTest >> readHeader [
 
 	| header |
-	header := 'lala.image' asFileReference binaryReadStreamDo: [ :f | 
+	header := self imageFileName asFileReference binaryReadStreamDo: [ :f | 
 		          imageReader readHeaderFrom: f startingAt: 0 ].
 	^ header
 ]
@@ -27,14 +33,13 @@ VMSpurImageFormatTest >> setUp [
 
 	interpreter extraVMMemory: 0.
 
-	interpreter imageName: 'lala.image'.
+	interpreter imageName: self imageFileName.
 	interpreter preemptionYields: false.
 	interpreter setImageHeaderFlagsFrom: 0.
 	
 	interpreter writeImageFileIO.
 	
-	imageReader := ImageReader new.
-	imageReader objectMemory: memory
+	imageReader := ImageReader newWithMemory: memory
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Fix https://github.com/pharo-project/opensmalltalk-vm/issues/357

Creating an ImageReader object and move there the responsibility to read an image file.

I kept the method `#readImageFromFile: f StartingAt: headerStart` in StackInterpreter because it only setups the interpreter state talking with a Header object (not with the file).

The CI is failing, I'm not sure why... I found [this message in the logs](https://github.com/tesonep/opensmalltalk-vm/runs/4468488708?check_suite_focus=true#step:5:236) on CMake config step: `FATALAggggh not implemented yet`